### PR TITLE
Managing keys and constraints using SQL

### DIFF
--- a/catalog/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/CatalogImpl.java
+++ b/catalog/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/CatalogImpl.java
@@ -995,8 +995,7 @@ public class CatalogImpl extends Catalog {
     public void addUniqueConstraint( long tableId, String constraintName, List<Long> columnIds ) throws GenericCatalogException {
         try {
             val transactionHandler = XATransactionHandler.getOrCreateTransactionHandler( xid );
-            long keyId = Statements.addKey( transactionHandler, tableId, true, constraintName, columnIds );
-            Statements.setPrimaryKey( transactionHandler, tableId, keyId );
+            Statements.addKey( transactionHandler, tableId, true, constraintName, columnIds );
         } catch ( CatalogConnectionException | CatalogTransactionException | GenericCatalogException e ) {
             throw new GenericCatalogException( e );
         }

--- a/catalog/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/CatalogImpl.java
+++ b/catalog/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/CatalogImpl.java
@@ -50,6 +50,7 @@ import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownCollationExcepti
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownColumnException;
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownDatabaseException;
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownEncodingException;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownIndexException;
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownKeyException;
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownSchemaException;
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownSchemaTypeException;
@@ -989,7 +990,7 @@ public class CatalogImpl extends Catalog {
      *
      * @param tableId The id of the table
      * @param constraintName The name of the constraint
-     * @param columnIds The id of key which will be part of the primary keys
+     * @param columnIds A list of column ids
      */
     @Override
     public void addUniqueConstraint( long tableId, String constraintName, List<Long> columnIds ) throws GenericCatalogException {
@@ -1021,15 +1022,91 @@ public class CatalogImpl extends Catalog {
 
 
     /**
+     * Returns the index with the specified name in the specified table
+     *
+     * @param tableId The id of the table
+     * @param indexName The name of the index
+     * @return The Index
+     */
+    @Override
+    public CatalogIndex getIndex( long tableId, String indexName ) throws GenericCatalogException, UnknownIndexException {
+        try {
+            val transactionHandler = XATransactionHandler.getOrCreateTransactionHandler( xid );
+            return Statements.getIndex( transactionHandler, tableId, indexName );
+        } catch ( CatalogConnectionException | GenericCatalogException | CatalogTransactionException e ) {
+            throw new GenericCatalogException( e );
+        }
+    }
+
+
+    /**
+     * Adds an index over the specified columns
+     *
+     * @param tableId The id of the table
+     * @param columnIds A list of column ids
+     * @param unique Weather the index should be unique
+     * @param indexName The name of the index
+     * @return The id of the created index
+     */
+    @Override
+    public long addIndex( long tableId, List<Long> columnIds, boolean unique, String indexName ) throws GenericCatalogException {
+        try {
+            val transactionHandler = XATransactionHandler.getOrCreateTransactionHandler( xid );
+            long keyId = -1;
+            // Check if there is already a key
+            List<CatalogKey> keys = Statements.getKeys( transactionHandler, tableId );
+            for ( CatalogKey key : keys ) {
+                if ( key.columnIds.size() == columnIds.size() && key.columnIds.containsAll( columnIds ) && columnIds.containsAll( key.columnIds ) ) {
+                    // If the index has the unique flag set, set the key unique if this is not already case
+                    if ( unique && !key.unique ) {
+                        Statements.setKeyUnique( transactionHandler, keyId, true );
+                    }
+                    keyId = key.id;
+                }
+            }
+            if ( keyId == -1 ) {
+                // There is no key, create it
+                keyId = Statements.addKey( transactionHandler, tableId, unique, indexName, columnIds );
+            }
+            IndexType type = IndexType.BTREE;
+            return Statements.addIndex( transactionHandler, keyId, type, null, indexName );
+        } catch ( CatalogConnectionException | CatalogTransactionException | GenericCatalogException e ) {
+            throw new GenericCatalogException( e );
+        }
+    }
+
+
+    /**
      * Delete the specified index
      *
      * @param indexId The id of the index to drop
      */
     @Override
-    public void deleteIndex( long indexId ) throws GenericCatalogException {
+    public void deleteIndex( long indexId ) throws GenericCatalogException, UnknownIndexException {
         try {
             val transactionHandler = XATransactionHandler.getOrCreateTransactionHandler( xid );
-            Statements.deleteIndex( transactionHandler, indexId );
+            CatalogIndex index = Statements.getIndex( transactionHandler, indexId );
+            Statements.deleteIndex( transactionHandler, index.id );
+
+            // Check if the key is used by a foreign key constraint.
+            List<CatalogForeignKey> foreignKeys = Statements.getForeignKeys( transactionHandler, index.key.tableId );
+            for ( CatalogForeignKey fk : foreignKeys ) {
+                if ( fk.id == index.keyId ) {
+                    return;
+                }
+            }
+            // Check if the key is used by a unique constraint or primary key
+            if ( index.key.unique ) {
+                return;
+            }
+            // Check if key is used by another index
+            List<CatalogIndex> indexes = Statements.getIndexesByKey( transactionHandler, index.key.id );
+            if ( indexes.size() > 0 ) {
+                return;
+            }
+
+            // This key is not used anymore. Delete it.
+            Statements.deleteKey( transactionHandler, index.key.id );
         } catch ( CatalogConnectionException | GenericCatalogException | CatalogTransactionException e ) {
             throw new GenericCatalogException( e );
         }

--- a/catalog/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/Statements.java
+++ b/catalog/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/Statements.java
@@ -1292,6 +1292,24 @@ final class Statements {
     }
 
 
+    public static long addKey( XATransactionHandler transactionHandler, long tableId, boolean unique, String name, List<Long> columnIds ) throws GenericCatalogException {
+        Map<String, String> data = new LinkedHashMap<>();
+        data.put( "table", "" + tableId );
+        data.put( "unique", "" + unique );
+        data.put( "name", quoteString( name ) );
+        long keyId = insertHandler( transactionHandler, "key", data );
+
+        for ( long columnId : columnIds ) {
+            Map<String, String> columnData = new LinkedHashMap<>();
+            columnData.put( "key", "" + keyId );
+            columnData.put( "column", "" + columnId );
+            insertHandler( transactionHandler, "key_column", columnData );
+        }
+
+        return keyId;
+    }
+
+
     public static List<CatalogForeignKey> getForeignKeys( TransactionHandler transactionHandler, long tableId ) throws GenericCatalogException {
         String keyFilter = " AND t.\"id\" = " + tableId;
         return foreignKeyFilter( transactionHandler, keyFilter );
@@ -1490,5 +1508,6 @@ final class Statements {
         }
         return v;
     }
+
 
 }

--- a/catalog/src/main/resources/catalogSchema.sql
+++ b/catalog/src/main/resources/catalogSchema.sql
@@ -172,7 +172,6 @@ CREATE TABLE "foreign_key" (
     "references"    BIGINT               NOT NULL REFERENCES "key" ("id"),
     "on_update"     INTEGER DEFAULT NULL NULL,
     "on_delete"     INTEGER DEFAULT NULL NULL,
-    "deferrability" INTEGER              NULL,
     PRIMARY KEY ("key")
 );
 
@@ -384,53 +383,3 @@ VALUES ( 0, 2 ),
        ( 1, 0 ),
        ( 1, 1 );
 
-
---
--- keys
---
-INSERT INTO "key" ( "id", "table", "unique", "name" )
-VALUES ( 0, 0, TRUE, 'key_0' ),
-       ( 1, 1, TRUE, 'key_1' ),
-       ( 2, 1, FALSE, 'key_2' ),
-       ( 3, 1, TRUE, 'key_3' ),
-       ( 4, 2, TRUE, 'key_4' );
-
-ALTER TABLE "key"
-    ALTER COLUMN "id"
-        RESTART WITH 5;
-
-UPDATE "table"
-SET "primary_key" = 0
-WHERE "id" = 0;
-
-
---
--- key columns
---
-INSERT INTO "key_column" ( "key", "column" )
-VALUES ( 0, 0 ),
-       ( 1, 1 ),
-       ( 2, 3 ),
-       ( 3, 3 ),
-       ( 3, 4 ),
-       ( 4, 8 );
-
-
---
--- foreign_key
---
-INSERT INTO "foreign_key" ( "key", "references", "on_update", "on_delete", "deferrability" )
-VALUES ( 2, 0, NULL, NULL, 0 );
-
-
---
--- index
---
-INSERT INTO "index" ( "id", "key", "type", "location", "name" )
-VALUES ( 0, 0, 0, NULL, 'i_0_0' ),
-       ( 1, 2, 0, NULL, 'i_2_0' ),
-       ( 2, 3, 0, NULL, 'i_3_0' );
-
-ALTER TABLE "index"
-    ALTER COLUMN "id"
-        RESTART WITH 2;

--- a/catalog/src/main/resources/catalogSchema.sql
+++ b/catalog/src/main/resources/catalogSchema.sql
@@ -431,6 +431,6 @@ VALUES ( 0, 0, 0, NULL, 'i_0_0' ),
        ( 1, 2, 0, NULL, 'i_2_0' ),
        ( 2, 3, 0, NULL, 'i_3_0' );
 
-ALTER TABLE "key"
+ALTER TABLE "index"
     ALTER COLUMN "id"
         RESTART WITH 2;

--- a/core/_docs/reference.md
+++ b/core/_docs/reference.md
@@ -87,14 +87,18 @@ alterStatement:
      | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName OWNER TO userName
      | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName RENAME COLUMN columnName TO newColumnName
      | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName DROP COLUMN columnName
-     | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName ADD COLUMN columnName type [ NULL | NOT NULL] [DEFAULT defaultValue] [(BEFORE | AFTER) columnName]
+     | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName ADD COLUMN columnName type [ NULL | NOT NULL ] [DEFAULT defaultValue] [(BEFORE | AFTER) columnName]
      | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName MODIFY COLUMN columnName SET NOT NULL
      | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName MODIFY COLUMN columnName DROP NOT NULL
      | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName MODIFY COLUMN columnName SET DEFAULT value
      | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName MODIFY COLUMN columnName DROP DEFAULT
      | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName MODIFY COLUMN columnName SET TYPE type
      | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName MODIFY COLUMN columnName SET POSITION ( BEFORE | AFTER ) columnName
-
+     | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName ADD PRIMARY KEY ( columnName | '(' columnName [ , columnName ]* ')' )
+     | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName DROP PRIMARY KEY
+     | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName ADD CONSTRAINT constraintName UNIQUE ( columnName| '(' columnName [ , columnName ]* ')' )
+     | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName ADD CONSTRAINT constraintName FOREIGN KEY ( columnName | '(' columnName [ , columnName ]* ')' ) REFERENCES [ databaseName . ] [ schemaName . ] tableName '(' columnName [ , columnName ]* ')' [ ON UPDATE ( CASCADE | RESTRICT | SET NULL | SET DEFAULT ) ] [ ON DELETE ( CASCADE | RESTRICT | SET NULL | SET DEFAULT ) ]
+     | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName DROP CONSTRAINT constraintName
 
 explain:
       EXPLAIN PLAN

--- a/core/_docs/reference.md
+++ b/core/_docs/reference.md
@@ -99,6 +99,8 @@ alterStatement:
      | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName ADD CONSTRAINT constraintName UNIQUE ( columnName| '(' columnName [ , columnName ]* ')' )
      | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName ADD CONSTRAINT constraintName FOREIGN KEY ( columnName | '(' columnName [ , columnName ]* ')' ) REFERENCES [ databaseName . ] [ schemaName . ] tableName '(' columnName [ , columnName ]* ')' [ ON UPDATE ( CASCADE | RESTRICT | SET NULL | SET DEFAULT ) ] [ ON DELETE ( CASCADE | RESTRICT | SET NULL | SET DEFAULT ) ]
      | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName DROP CONSTRAINT constraintName
+     | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName ADD [UNIQUE] INDEX indexName ON ( columnName | '(' columnName [ , columnName ]* ')' ) 
+     | ALTER TABLE [ databaseName . ] [ schemaName . ] tableName DROP INDEX indexName
 
 explain:
       EXPLAIN PLAN
@@ -537,6 +539,7 @@ IMPLEMENTATION,
 **IN**,
 INCLUDING,
 INCREMENT,
+INDEX,
 **INDICATOR**,
 **INITIAL**,
 INITIALLY,

--- a/core/src/main/codegen/config.fmpp
+++ b/core/src/main/codegen/config.fmpp
@@ -147,6 +147,7 @@ data: {
             "IMPLEMENTATION"
             "INCLUDING"
             "INCREMENT"
+            "INDEX"
             "INITIALLY"
             "INPUT"
             "INSTANCE"

--- a/core/src/main/codegen/includes/ddlParser.ftl
+++ b/core/src/main/codegen/includes/ddlParser.ftl
@@ -182,8 +182,7 @@ SqlNodeList AttributeDefList() :
 {
     final Span s;
     final List
-    <SqlNode> list = new ArrayList
-    <SqlNode>();
+    <SqlNode> list = new ArrayList<SqlNode>();
 }
 {
     <LPAREN> { s = span(); }

--- a/core/src/main/codegen/includes/parserImpls.ftl
+++ b/core/src/main/codegen/includes/parserImpls.ftl
@@ -77,6 +77,7 @@ SqlAlterTable SqlAlterTable(Span s) :
     final SqlIdentifier beforeColumn;
     final SqlIdentifier afterColumn;
     final SqlAlterTable statement;
+    final SqlNodeList columnList;
 }
 {
     <TABLE>
@@ -133,6 +134,23 @@ SqlAlterTable SqlAlterTable(Span s) :
             column = SimpleIdentifier()
             {
                 return new SqlAlterTableDropColumn(s.end(this), table, column);
+            }
+        |
+            <ADD> <PRIMARY> <KEY>
+            (
+                columnList = ParenthesizedSimpleIdentifierList()
+                |
+                column = SimpleIdentifier() {
+                    columnList = new SqlNodeList(Arrays.asList( new SqlNode[]{ column }), s.end(this));
+                }
+            )
+            {
+                return new SqlAlterTableAddPrimaryKey(s.end(this), table, columnList);
+            }
+        |
+            <DROP> <PRIMARY> <KEY>
+            {
+                return new SqlAlterTableDropPrimaryKey(s.end(this), table);
             }
         |
             <MODIFY> <COLUMN>

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -6262,6 +6262,7 @@ SqlPostfixOperator PostfixRowOperator() :
 |   < IN: "IN" >
 |   < INCLUDING: "INCLUDING" >
 |   < INCREMENT: "INCREMENT" >
+|   < INDEX: "INDEX" >
 |   < INDICATOR: "INDICATOR" >
 |   < INITIAL: "INITIAL" >
 |   < INITIALLY: "INITIALLY" >

--- a/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/Catalog.java
+++ b/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/Catalog.java
@@ -511,6 +511,15 @@ public abstract class Catalog {
 
 
     /**
+     * Adds a primary key
+     *
+     * @param tableId The id of the table
+     * @param columnIds The id of key which will be part of the primary keys
+     */
+    public abstract void addPrimaryKey( long tableId, List<Long> columnIds ) throws GenericCatalogException;
+
+
+    /**
      * Returns all (imported) foreign keys of a specified table
      *
      * @param tableId The id of the table
@@ -552,6 +561,14 @@ public abstract class Catalog {
      * @param keyId The id of the key to drop
      */
     public abstract void deleteKey( long keyId ) throws GenericCatalogException;
+
+
+    /**
+     * Deletes the specified foreign key (including the entry in the key table). If there is an index on this key, make sure to delete it first.
+     *
+     * @param tableId The id of the key to drop
+     */
+    public abstract void deletePrimaryKey( long tableId ) throws GenericCatalogException;
 
 
     /**

--- a/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/Catalog.java
+++ b/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/Catalog.java
@@ -48,6 +48,8 @@ import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownColumnException;
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownDatabaseException;
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownEncodingException;
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownForeignKeyOptionException;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownIndexException;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownIndexTypeException;
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownKeyException;
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownSchemaException;
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownSchemaTypeException;
@@ -557,7 +559,7 @@ public abstract class Catalog {
      *
      * @param tableId The id of the table
      * @param constraintName The name of the constraint
-     * @param columnIds The id of key which will be part of the primary keys
+     * @param columnIds A list of column ids
      */
     public abstract void addUniqueConstraint( long tableId, String constraintName, List<Long> columnIds ) throws GenericCatalogException;
 
@@ -572,11 +574,33 @@ public abstract class Catalog {
 
 
     /**
+     * Returns the index with the specified name in the specified table
+     *
+     * @param tableId The id of the table
+     * @param indexName The name of the index
+     * @return The Index
+     */
+    public abstract CatalogIndex getIndex( long tableId, String indexName ) throws GenericCatalogException, UnknownIndexException;
+
+
+    /**
+     * Adds an index over the specified columns
+     *
+     * @param tableId The id of the table
+     * @param columnIds A list of column ids
+     * @param unique Weather the index should be unique
+     * @param indexName The name of the index
+     * @return The id of the created index
+     */
+    public abstract long addIndex( long tableId, List<Long> columnIds, boolean unique, String indexName ) throws GenericCatalogException;
+
+
+    /**
      * Delete the specified index
      *
      * @param indexId The id of the index to drop
      */
-    public abstract void deleteIndex( long indexId ) throws GenericCatalogException;
+    public abstract void deleteIndex( long indexId ) throws GenericCatalogException, UnknownIndexException;
 
 
     /**
@@ -789,6 +813,33 @@ public abstract class Catalog {
                 }
             }
             throw new UnknownEncodingException( id );
+        }
+    }
+
+
+    public enum IndexType {
+        BTREE( 1 );
+
+        private final int id;
+
+
+        IndexType( int id ) {
+            this.id = id;
+        }
+
+
+        public int getId() {
+            return id;
+        }
+
+
+        public static IndexType getById( int id ) throws UnknownIndexTypeException {
+            for ( IndexType e : values() ) {
+                if ( e.id == id ) {
+                    return e;
+                }
+            }
+            throw new UnknownIndexTypeException( id );
         }
     }
 

--- a/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/entity/CatalogForeignKey.java
+++ b/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/entity/CatalogForeignKey.java
@@ -52,7 +52,6 @@ public final class CatalogForeignKey extends CatalogKey {
     public final String referencedKeyTableName;
     public final Integer updateRule;
     public final Integer deleteRule;
-    public final int deferrability;
     public List<Long> referencedKeyColumnIds;
     public List<String> referencedKeyColumnNames;
 
@@ -76,8 +75,7 @@ public final class CatalogForeignKey extends CatalogKey {
             final long referencedKeyDatabaseId,
             @NonNull final String referencedKeyDatabaseName,
             final Integer updateRule,
-            final Integer deleteRule,
-            final int deferrability ) {
+            final Integer deleteRule ) {
         super( id, name, tableId, tableName, schemaId, schemaName, databaseId, databaseName, unique );
         this.referencedKeyId = referencedKeyId;
         this.referencedKeyName = referencedKeyName;
@@ -89,7 +87,6 @@ public final class CatalogForeignKey extends CatalogKey {
         this.referencedKeyDatabaseName = referencedKeyDatabaseName;
         this.updateRule = updateRule;
         this.deleteRule = deleteRule;
-        this.deferrability = deferrability;
     }
 
 
@@ -115,7 +112,7 @@ public final class CatalogForeignKey extends CatalogKey {
 
         @Override
         public Serializable[] getParameterArray() {
-            return new Serializable[]{ referencedKeyDatabaseName, referencedKeySchemaName, referencedKeyTableName, referencedKeyColumnName, databaseName, schemaName, tableName, foreignKeyColumnName, keySeq, updateRule, deleteRule, name, referencedKeyName, deferrability };
+            return new Serializable[]{ referencedKeyDatabaseName, referencedKeySchemaName, referencedKeyTableName, referencedKeyColumnName, databaseName, schemaName, tableName, foreignKeyColumnName, keySeq, updateRule, deleteRule, name, referencedKeyName, null };
         }
 
 
@@ -135,7 +132,7 @@ public final class CatalogForeignKey extends CatalogKey {
             public final Integer deleteRule;
             public final String fkName;
             public final String pkName;
-            public final int deferrability;
+            public final Integer deferrability;
         }
 
     }

--- a/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/exceptions/UnknownForeignKeyOptionException.java
+++ b/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/exceptions/UnknownForeignKeyOptionException.java
@@ -1,0 +1,39 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Databases and Information Systems Research Group, University of Basel, Switzerland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions;
+
+
+public class UnknownForeignKeyOptionException extends CatalogException {
+
+    public UnknownForeignKeyOptionException( String name ) {
+        super( "There is no Foreign Key Option with name: " + name );
+    }
+
+
+    public UnknownForeignKeyOptionException( int id ) {
+        super( "There is no Foreign Key Option with id: " + id );
+    }
+}

--- a/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/exceptions/UnknownIndexException.java
+++ b/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/exceptions/UnknownIndexException.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Databases and Information Systems Research Group, University of Basel, Switzerland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions;
+
+
+public class UnknownIndexException extends CatalogException {
+
+
+    public UnknownIndexException( String indexName ) {
+        super( "There is no index with this name: '" + indexName + "'." );
+    }
+
+
+    public UnknownIndexException( long indexId ) {
+        super( "Unknown index id: " + indexId + ". There is no index with this id." );
+    }
+}

--- a/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/exceptions/UnknownIndexTypeException.java
+++ b/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/exceptions/UnknownIndexTypeException.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Databases and Information Systems Research Group, University of Basel, Switzerland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions;
+
+
+public class UnknownIndexTypeException extends CatalogException {
+
+
+    public UnknownIndexTypeException( String name ) {
+        super( "There is no index type with this name: '" + name + "'." );
+    }
+
+
+    public UnknownIndexTypeException( long id ) {
+        super( "Unknown index type id: " + id + ". There is no index type with this id." );
+    }
+}

--- a/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/sql/ddl/SqlDropTable.java
+++ b/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/sql/ddl/SqlDropTable.java
@@ -160,7 +160,7 @@ public class SqlDropTable extends SqlDropObject {
         // Delete keys
         try {
             // Remove primary key
-            transaction.getCatalog().setPrimaryKey( table.getTable().id, null );
+            transaction.getCatalog().deletePrimaryKey( table.getTable().id );
             // Delete all foreign keys of the table
             List<CatalogForeignKey> foreignKeys = transaction.getCatalog().getForeignKeys( table.getTable().id );
             for ( CatalogForeignKey foreignKey : foreignKeys ) {

--- a/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/sql/ddl/SqlDropTable.java
+++ b/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/sql/ddl/SqlDropTable.java
@@ -59,6 +59,7 @@ import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.GenericCatalogException
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownCollationException;
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownDatabaseException;
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownEncodingException;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownIndexException;
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownKeyException;
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownSchemaException;
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownSchemaTypeException;
@@ -154,7 +155,7 @@ public class SqlDropTable extends SqlDropObject {
             for ( CatalogIndex index : indexes ) {
                 transaction.getCatalog().deleteIndex( index.id );
             }
-        } catch ( GenericCatalogException e ) {
+        } catch ( GenericCatalogException | UnknownIndexException e ) {
             throw new PolyphenyDbContextException( "Exception while dropping indexes.", e );
         }
 

--- a/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/sql/ddl/SqlDropTable.java
+++ b/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/sql/ddl/SqlDropTable.java
@@ -59,6 +59,7 @@ import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.GenericCatalogException
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownCollationException;
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownDatabaseException;
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownEncodingException;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownKeyException;
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownSchemaException;
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownSchemaTypeException;
 import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownTableException;
@@ -164,13 +165,13 @@ public class SqlDropTable extends SqlDropObject {
             // Delete all foreign keys of the table
             List<CatalogForeignKey> foreignKeys = transaction.getCatalog().getForeignKeys( table.getTable().id );
             for ( CatalogForeignKey foreignKey : foreignKeys ) {
-                transaction.getCatalog().deleteForeignKey( foreignKey.id );
+                transaction.getCatalog().deleteConstraint( table.getTable().id, foreignKey.name );
             }
             // Delete all remaining keys (unique keys and the primary key) of the table
             for ( CatalogKey key : transaction.getCatalog().getKeys( table.getTable().id ) ) {
                 transaction.getCatalog().deleteKey( key.id );
             }
-        } catch ( GenericCatalogException e ) {
+        } catch ( GenericCatalogException | UnknownKeyException e ) {
             throw new PolyphenyDbContextException( "Exception while dropping keys.", e );
         }
 

--- a/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/sql/ddl/SqlKeyConstraint.java
+++ b/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/sql/ddl/SqlKeyConstraint.java
@@ -56,6 +56,7 @@ import ch.unibas.dmi.dbis.polyphenydb.sql.SqlWriter;
 import ch.unibas.dmi.dbis.polyphenydb.sql.parser.SqlParserPos;
 import ch.unibas.dmi.dbis.polyphenydb.util.ImmutableNullableList;
 import java.util.List;
+import lombok.Getter;
 
 
 /**
@@ -65,11 +66,13 @@ import java.util.List;
  */
 public class SqlKeyConstraint extends SqlCall {
 
-    private static final SqlSpecialOperator UNIQUE = new SqlSpecialOperator( "UNIQUE", SqlKind.UNIQUE );
+    public static final SqlSpecialOperator UNIQUE = new SqlSpecialOperator( "UNIQUE", SqlKind.UNIQUE );
 
     protected static final SqlSpecialOperator PRIMARY = new SqlSpecialOperator( "PRIMARY KEY", SqlKind.PRIMARY_KEY );
 
+    @Getter
     private final SqlIdentifier name;
+    @Getter
     private final SqlNodeList columnList;
 
 

--- a/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/sql/ddl/altertable/SqlAlterTableAddForeignKeyConstraint.java
+++ b/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/sql/ddl/altertable/SqlAlterTableAddForeignKeyConstraint.java
@@ -1,0 +1,130 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Databases and Information Systems Research Group, University of Basel, Switzerland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package ch.unibas.dmi.dbis.polyphenydb.sql.ddl.altertable;
+
+
+import ch.unibas.dmi.dbis.polyphenydb.Transaction;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.Catalog.ForeignKeyOption;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.entity.CatalogColumn;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.entity.CatalogTable;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.GenericCatalogException;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownColumnException;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownForeignKeyOptionException;
+import ch.unibas.dmi.dbis.polyphenydb.jdbc.Context;
+import ch.unibas.dmi.dbis.polyphenydb.sql.SqlIdentifier;
+import ch.unibas.dmi.dbis.polyphenydb.sql.SqlNode;
+import ch.unibas.dmi.dbis.polyphenydb.sql.SqlNodeList;
+import ch.unibas.dmi.dbis.polyphenydb.sql.SqlWriter;
+import ch.unibas.dmi.dbis.polyphenydb.sql.ddl.SqlAlterTable;
+import ch.unibas.dmi.dbis.polyphenydb.sql.parser.SqlParserPos;
+import ch.unibas.dmi.dbis.polyphenydb.util.ImmutableNullableList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+
+/**
+ * Parse tree for {@code ALTER TABLE name ADD CONSTRAINT FOREIGN KEY} statement.
+ */
+public class SqlAlterTableAddForeignKeyConstraint extends SqlAlterTable {
+
+    private final SqlIdentifier table;
+    private final SqlIdentifier constraintName;
+    private final SqlNodeList columnList;
+    private final SqlIdentifier referencesTable;
+    private final SqlNodeList referencesList;
+    private final ForeignKeyOption onUpdate;
+    private final ForeignKeyOption onDelete;
+
+
+    public SqlAlterTableAddForeignKeyConstraint( SqlParserPos pos, SqlIdentifier table, SqlIdentifier constraintName, SqlNodeList columnList, SqlIdentifier referencesTable, SqlNodeList referencesList, String onUpdate, String onDelete ) {
+        super( pos );
+        this.table = Objects.requireNonNull( table );
+        this.constraintName = Objects.requireNonNull( constraintName );
+        this.columnList = Objects.requireNonNull( columnList );
+        this.referencesTable = Objects.requireNonNull( referencesTable );
+        this.referencesList = Objects.requireNonNull( referencesList );
+        try {
+            this.onUpdate = onUpdate != null ? ForeignKeyOption.parse( onUpdate ) : ForeignKeyOption.RESTRICT;
+            this.onDelete = onDelete != null ? ForeignKeyOption.parse( onDelete ) : ForeignKeyOption.RESTRICT;
+        } catch ( UnknownForeignKeyOptionException e ) {
+            throw new RuntimeException( e );
+        }
+    }
+
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        return ImmutableNullableList.of( table, constraintName, columnList, referencesList );
+    }
+
+
+    @Override
+    public void unparse( SqlWriter writer, int leftPrec, int rightPrec ) {
+        writer.keyword( "ALTER" );
+        writer.keyword( "TABLE" );
+        table.unparse( writer, leftPrec, rightPrec );
+        writer.keyword( "ADD" );
+        constraintName.unparse( writer, leftPrec, rightPrec );
+        writer.keyword( "FOREIGN" );
+        writer.keyword( "KEY" );
+        columnList.unparse( writer, leftPrec, rightPrec );
+        writer.keyword( "REFERENCES" );
+        referencesList.unparse( writer, leftPrec, rightPrec );
+        writer.keyword( "ON" );
+        writer.keyword( "UPDATE" );
+        writer.keyword( onUpdate.name() );
+        writer.keyword( "ON" );
+        writer.keyword( "DELETE" );
+        writer.keyword( onDelete.name() );
+    }
+
+
+    @Override
+    public void execute( Context context, Transaction transaction ) {
+        CatalogTable catalogTable = getCatalogTable( context, transaction, table );
+        CatalogTable refTable = getCatalogTable( context, transaction, referencesTable );
+        try {
+            List<Long> columnIds = new LinkedList<>();
+            for ( SqlNode node : columnList.getList() ) {
+                String columnName = node.toString();
+                CatalogColumn catalogColumn = transaction.getCatalog().getColumn( catalogTable.id, columnName );
+                columnIds.add( catalogColumn.id );
+            }
+            List<Long> referencesIds = new LinkedList<>();
+            for ( SqlNode node : referencesList.getList() ) {
+                String columnName = node.toString();
+                CatalogColumn catalogColumn = transaction.getCatalog().getColumn( refTable.id, columnName );
+                referencesIds.add( catalogColumn.id );
+            }
+            transaction.getCatalog().addForeignKey( catalogTable.id, columnIds, refTable.id, referencesIds, constraintName.getSimple(), onUpdate, onDelete );
+        } catch ( GenericCatalogException | UnknownColumnException e ) {
+            throw new RuntimeException( e );
+        }
+    }
+
+}
+

--- a/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/sql/ddl/altertable/SqlAlterTableAddPrimaryKey.java
+++ b/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/sql/ddl/altertable/SqlAlterTableAddPrimaryKey.java
@@ -1,0 +1,98 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Databases and Information Systems Research Group, University of Basel, Switzerland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package ch.unibas.dmi.dbis.polyphenydb.sql.ddl.altertable;
+
+
+import ch.unibas.dmi.dbis.polyphenydb.Transaction;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.entity.CatalogColumn;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.entity.CatalogTable;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.GenericCatalogException;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownColumnException;
+import ch.unibas.dmi.dbis.polyphenydb.jdbc.Context;
+import ch.unibas.dmi.dbis.polyphenydb.sql.SqlIdentifier;
+import ch.unibas.dmi.dbis.polyphenydb.sql.SqlNode;
+import ch.unibas.dmi.dbis.polyphenydb.sql.SqlNodeList;
+import ch.unibas.dmi.dbis.polyphenydb.sql.SqlWriter;
+import ch.unibas.dmi.dbis.polyphenydb.sql.ddl.SqlAlterTable;
+import ch.unibas.dmi.dbis.polyphenydb.sql.parser.SqlParserPos;
+import ch.unibas.dmi.dbis.polyphenydb.util.ImmutableNullableList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+
+/**
+ * Parse tree for {@code ALTER TABLE name ADD PRIMARY KEY} statement.
+ */
+public class SqlAlterTableAddPrimaryKey extends SqlAlterTable {
+
+    private final SqlIdentifier table;
+    private final SqlNodeList columnList;
+
+
+    public SqlAlterTableAddPrimaryKey( SqlParserPos pos, SqlIdentifier table, SqlNodeList columnList ) {
+        super( pos );
+        this.table = Objects.requireNonNull( table );
+        this.columnList = Objects.requireNonNull( columnList );
+    }
+
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        return ImmutableNullableList.of( table, columnList );
+    }
+
+
+    @Override
+    public void unparse( SqlWriter writer, int leftPrec, int rightPrec ) {
+        writer.keyword( "ALTER" );
+        writer.keyword( "TABLE" );
+        table.unparse( writer, leftPrec, rightPrec );
+        writer.keyword( "ADD" );
+        writer.keyword( "PRIMARY" );
+        writer.keyword( "KEY" );
+        columnList.unparse( writer, leftPrec, rightPrec );
+    }
+
+
+    @Override
+    public void execute( Context context, Transaction transaction ) {
+        CatalogTable catalogTable = getCatalogTable( context, transaction, table );
+        try {
+            List<Long> columnIds = new LinkedList<>();
+            for ( SqlNode node : columnList.getList() ) {
+                String columnName = node.toString();
+                CatalogColumn catalogColumn = transaction.getCatalog().getColumn( catalogTable.id, columnName );
+                columnIds.add( catalogColumn.id );
+            }
+            transaction.getCatalog().addPrimaryKey( catalogTable.id, columnIds );
+        } catch ( GenericCatalogException | UnknownColumnException e ) {
+            throw new RuntimeException( e );
+        }
+    }
+
+}
+

--- a/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/sql/ddl/altertable/SqlAlterTableAddUniqueConstraint.java
+++ b/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/sql/ddl/altertable/SqlAlterTableAddUniqueConstraint.java
@@ -1,0 +1,101 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Databases and Information Systems Research Group, University of Basel, Switzerland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package ch.unibas.dmi.dbis.polyphenydb.sql.ddl.altertable;
+
+
+import ch.unibas.dmi.dbis.polyphenydb.Transaction;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.entity.CatalogColumn;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.entity.CatalogTable;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.GenericCatalogException;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownColumnException;
+import ch.unibas.dmi.dbis.polyphenydb.jdbc.Context;
+import ch.unibas.dmi.dbis.polyphenydb.sql.SqlIdentifier;
+import ch.unibas.dmi.dbis.polyphenydb.sql.SqlNode;
+import ch.unibas.dmi.dbis.polyphenydb.sql.SqlNodeList;
+import ch.unibas.dmi.dbis.polyphenydb.sql.SqlWriter;
+import ch.unibas.dmi.dbis.polyphenydb.sql.ddl.SqlAlterTable;
+import ch.unibas.dmi.dbis.polyphenydb.sql.parser.SqlParserPos;
+import ch.unibas.dmi.dbis.polyphenydb.util.ImmutableNullableList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+
+/**
+ * Parse tree for {@code ALTER TABLE name ADD CONSTRAINT UNIQUE} statement.
+ */
+public class SqlAlterTableAddUniqueConstraint extends SqlAlterTable {
+
+    private final SqlIdentifier table;
+    private final SqlIdentifier constraintName;
+    private final SqlNodeList columnList;
+
+
+    public SqlAlterTableAddUniqueConstraint( SqlParserPos pos, SqlIdentifier table, SqlIdentifier constraintName, SqlNodeList columnList ) {
+        super( pos );
+        this.table = Objects.requireNonNull( table );
+        this.constraintName = Objects.requireNonNull( constraintName );
+        this.columnList = Objects.requireNonNull( columnList );
+    }
+
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        return ImmutableNullableList.of( table, columnList );
+    }
+
+
+    @Override
+    public void unparse( SqlWriter writer, int leftPrec, int rightPrec ) {
+        writer.keyword( "ALTER" );
+        writer.keyword( "TABLE" );
+        table.unparse( writer, leftPrec, rightPrec );
+        writer.keyword( "ADD" );
+        writer.keyword( "CONSTRAINT" );
+        constraintName.unparse( writer, leftPrec, rightPrec );
+        writer.keyword( "UNIQUE" );
+        columnList.unparse( writer, leftPrec, rightPrec );
+    }
+
+
+    @Override
+    public void execute( Context context, Transaction transaction ) {
+        CatalogTable catalogTable = getCatalogTable( context, transaction, table );
+        try {
+            List<Long> columnIds = new LinkedList<>();
+            for ( SqlNode node : columnList.getList() ) {
+                String columnName = node.toString();
+                CatalogColumn catalogColumn = transaction.getCatalog().getColumn( catalogTable.id, columnName );
+                columnIds.add( catalogColumn.id );
+            }
+            transaction.getCatalog().addUniqueConstraint( catalogTable.id, constraintName.getSimple(), columnIds );
+        } catch ( GenericCatalogException | UnknownColumnException e ) {
+            throw new RuntimeException( e );
+        }
+    }
+
+}
+

--- a/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/sql/ddl/altertable/SqlAlterTableDropConstraint.java
+++ b/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/sql/ddl/altertable/SqlAlterTableDropConstraint.java
@@ -1,0 +1,87 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Databases and Information Systems Research Group, University of Basel, Switzerland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package ch.unibas.dmi.dbis.polyphenydb.sql.ddl.altertable;
+
+
+import ch.unibas.dmi.dbis.polyphenydb.Transaction;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.entity.CatalogTable;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.GenericCatalogException;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.UnknownKeyException;
+import ch.unibas.dmi.dbis.polyphenydb.jdbc.Context;
+import ch.unibas.dmi.dbis.polyphenydb.sql.SqlIdentifier;
+import ch.unibas.dmi.dbis.polyphenydb.sql.SqlNode;
+import ch.unibas.dmi.dbis.polyphenydb.sql.SqlWriter;
+import ch.unibas.dmi.dbis.polyphenydb.sql.ddl.SqlAlterTable;
+import ch.unibas.dmi.dbis.polyphenydb.sql.parser.SqlParserPos;
+import ch.unibas.dmi.dbis.polyphenydb.util.ImmutableNullableList;
+import java.util.List;
+import java.util.Objects;
+
+
+/**
+ * Parse tree for {@code ALTER TABLE name DROP CONSTRAINT} statement.
+ */
+public class SqlAlterTableDropConstraint extends SqlAlterTable {
+
+    private final SqlIdentifier table;
+    private final SqlIdentifier constraintName;
+
+
+    public SqlAlterTableDropConstraint( SqlParserPos pos, SqlIdentifier table, SqlIdentifier constraintName ) {
+        super( pos );
+        this.table = Objects.requireNonNull( table );
+        this.constraintName = Objects.requireNonNull( constraintName );
+    }
+
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        return ImmutableNullableList.of( table, constraintName );
+    }
+
+
+    @Override
+    public void unparse( SqlWriter writer, int leftPrec, int rightPrec ) {
+        writer.keyword( "ALTER" );
+        writer.keyword( "TABLE" );
+        table.unparse( writer, leftPrec, rightPrec );
+        writer.keyword( "DROP" );
+        constraintName.unparse( writer, leftPrec, rightPrec );
+    }
+
+
+    @Override
+    public void execute( Context context, Transaction transaction ) {
+        CatalogTable catalogTable = getCatalogTable( context, transaction, table );
+        try {
+            transaction.getCatalog().deleteConstraint( catalogTable.id, constraintName.getSimple() );
+        } catch ( GenericCatalogException | UnknownKeyException e ) {
+            throw new RuntimeException( e );
+        }
+    }
+
+}
+

--- a/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/sql/ddl/altertable/SqlAlterTableDropPrimaryKey.java
+++ b/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/sql/ddl/altertable/SqlAlterTableDropPrimaryKey.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Databases and Information Systems Research Group, University of Basel, Switzerland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package ch.unibas.dmi.dbis.polyphenydb.sql.ddl.altertable;
+
+
+import ch.unibas.dmi.dbis.polyphenydb.Transaction;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.entity.CatalogTable;
+import ch.unibas.dmi.dbis.polyphenydb.catalog.exceptions.GenericCatalogException;
+import ch.unibas.dmi.dbis.polyphenydb.jdbc.Context;
+import ch.unibas.dmi.dbis.polyphenydb.sql.SqlIdentifier;
+import ch.unibas.dmi.dbis.polyphenydb.sql.SqlNode;
+import ch.unibas.dmi.dbis.polyphenydb.sql.SqlWriter;
+import ch.unibas.dmi.dbis.polyphenydb.sql.ddl.SqlAlterTable;
+import ch.unibas.dmi.dbis.polyphenydb.sql.parser.SqlParserPos;
+import ch.unibas.dmi.dbis.polyphenydb.util.ImmutableNullableList;
+import java.util.List;
+import java.util.Objects;
+
+
+/**
+ * Parse tree for {@code ALTER TABLE name DROP PRIMARY KEY} statement.
+ */
+public class SqlAlterTableDropPrimaryKey extends SqlAlterTable {
+
+    private final SqlIdentifier table;
+
+
+    public SqlAlterTableDropPrimaryKey( SqlParserPos pos, SqlIdentifier table ) {
+        super( pos );
+        this.table = Objects.requireNonNull( table );
+    }
+
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        return ImmutableNullableList.of( table );
+    }
+
+
+    @Override
+    public void unparse( SqlWriter writer, int leftPrec, int rightPrec ) {
+        writer.keyword( "ALTER" );
+        writer.keyword( "TABLE" );
+        table.unparse( writer, leftPrec, rightPrec );
+        writer.keyword( "DROP" );
+        writer.keyword( "PRIMARY" );
+        writer.keyword( "KEY" );
+    }
+
+
+    @Override
+    public void execute( Context context, Transaction transaction ) {
+        CatalogTable catalogTable = getCatalogTable( context, transaction, table );
+        try {
+            transaction.getCatalog().deletePrimaryKey( catalogTable.id );
+        } catch ( GenericCatalogException e ) {
+            throw new RuntimeException( e );
+        }
+    }
+
+}
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,6 @@
 versionMajor = 1
 versionMinor = 0
 versionQualifier = -SNAPSHOT
+
+org.gradle.daemon = true
+org.gradle.jvmargs = -Xmx4g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/jdbc-interface/src/main/java/ch/unibas/dmi/dbis/polyphenydb/jdbc/DbmsMeta.java
+++ b/jdbc-interface/src/main/java/ch/unibas/dmi/dbis/polyphenydb/jdbc/DbmsMeta.java
@@ -556,7 +556,7 @@ public class DbmsMeta implements ProtobufMeta {
                     "DELETE_RULE",            // What happens to a foreign key when the primary key is deleted.
                     "FK_NAME",                // The name of the foreign key.
                     "PK_NAME",                // The name of the primary key.
-                    "DEFERRABILITY"           // Indicates if the evaluation of the foreign key constraint can be deferred until a commit.
+                    "DEFERRABILITY"           // Indicates if the evaluation of the foreign key constraint can be deferred until a commit. --> always null
             );
         } catch ( GenericCatalogException e ) {
             throw propagate( e );


### PR DESCRIPTION
Add support for the following statements:

ALTER TABLE [ _database_name_ . ] [ _schema_name_ . ] _table_name_

- ADD PRIMARY KEY _column_name_
- ADD PRIMARY KEY (_column_name_, column_name, ...)
- DROP PRIMARY KEY
- ADD CONSTRAINT _constraint_name_ UNIQUE  _column_name_
- ADD CONSTRAINT _constraint_name_ UNIQUE (_column_name_, column_name, ...)
- ADD CONSTRAINT _constraint_name_ FOREIGN KEY _column_name_ REFERENCES [ databaseName . ] [ schemaName . ] tableName (_column_name_, column_name, ...) [ ON UPDATE ( CASCADE | RESTRICT | SET NULL | SET DEFAULT ) ] [ ON DELETE ( CASCADE | RESTRICT | SET NULL | SET DEFAULT ) ]
- ADD CONSTRAINT _constraint_name_ FOREIGN KEY (_column_name_, column_name, ...) REFERENCES [ databaseName . ] [ schemaName . ] tableName (_column_name_, column_name, ...) [ ON UPDATE ( CASCADE | RESTRICT | SET NULL | SET DEFAULT ) ] [ ON DELETE ( CASCADE | RESTRICT | SET NULL | SET DEFAULT ) ]
- DROP CONSTRAINT _constraint_name_
- ADD [UNIQUE] INDEX _index_name_ ON _column_name_
- ADD [UNIQUE] INDEX _index_name_ ON (_column_name_, column_name, ...)
- DROP INDEX _index_name_

Furthermore, this PR adds support for defining the primary key and unique constraints in the create table statement:

CREATE TABLE test (
  id integer,
  name varchar(20),
  PRIMARY KEY(id),
  [CONSTRAINT _constraint_name_] UNIQUE(name)
}

This pull request only adds support for modifying the schema stored in the catalog. There is no support by the other parts of Polypheny-DB yet.