### PR TITLE
Improve query handling

### DIFF
--- a/catalog/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/CatalogImpl.java
+++ b/catalog/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/CatalogImpl.java
@@ -771,8 +771,19 @@ public class CatalogImpl extends Catalog {
     public void setNullable( long columnId, boolean nullable ) throws GenericCatalogException {
         try {
             val transactionHandler = XATransactionHandler.getOrCreateTransactionHandler( xid );
+
+            if ( nullable ) {
+                // Check if the column is part of a primary key (pk's are not allowed to contain null values)
+                CatalogColumn catalogColumn = Statements.getColumn( transactionHandler, columnId );
+                CatalogTable catalogTable = Statements.getTable( transactionHandler, catalogColumn.tableId );
+                CatalogKey catalogKey = Statements.getPrimaryKey( transactionHandler, catalogTable.primaryKey );
+                if ( catalogKey.columnIds.contains( columnId ) ) {
+                    throw new GenericCatalogException( "Unable to allow null values in a column that is part of the primary key." );
+                }
+            }
+
             Statements.setNullable( transactionHandler, columnId, nullable );
-        } catch ( CatalogConnectionException | CatalogTransactionException e ) {
+        } catch ( CatalogConnectionException | CatalogTransactionException | UnknownCollationException | UnknownTypeException | UnknownColumnException | UnknownTableTypeException | UnknownTableException | UnknownKeyException e ) {
             throw new GenericCatalogException( e );
         }
     }
@@ -906,21 +917,30 @@ public class CatalogImpl extends Catalog {
             val transactionHandler = XATransactionHandler.getOrCreateTransactionHandler( xid );
             CatalogTable catalogTable = Statements.getTable( transactionHandler, tableId );
 
+            // Check if the columns are set 'not null'
+            for ( Long columnId : columnIds ) {
+                CatalogColumn catalogColumn = Statements.getColumn( transactionHandler, columnId );
+                if ( catalogColumn.nullable ) {
+                    throw new GenericCatalogException( "Primary key is not allowed to contain null values but the column '" + catalogColumn.name + "' is declared nullable." );
+                }
+            }
+
             // TODO: Check if the current values are unique
 
             // Check if there is already a primary key defined for this table and if so, delete it.
-            if ( catalogTable.primaryKey != null ) {
-                CatalogCombinedKey combinedKey = getCombinedKey( catalogTable.primaryKey );
+            Long oldPrimaryKey = catalogTable.primaryKey;
+            if ( oldPrimaryKey != null ) {
+                CatalogCombinedKey combinedKey = getCombinedKey( oldPrimaryKey );
                 if ( combinedKey.getUniqueCount() == 1 && combinedKey.getReferencedBy().size() > 0 ) {
                     // This primary key is the only constraint for the uniqueness of this key.
                     throw new GenericCatalogException( "This key is referenced by at least one foreign key which requires this key to be unique. To drop this primary key, first drop the foreign keys or create a unique constraint." );
                 }
                 Statements.setPrimaryKey( transactionHandler, tableId, null );
-                deleteKeyIfNoLongerUsed( transactionHandler, catalogTable.primaryKey );
+                deleteKeyIfNoLongerUsed( transactionHandler, oldPrimaryKey );
             }
             long keyId = getOrAddKey( transactionHandler, tableId, columnIds );
             Statements.setPrimaryKey( transactionHandler, tableId, keyId );
-        } catch ( CatalogConnectionException | CatalogTransactionException | UnknownTableTypeException | UnknownTableException | UnknownKeyException e ) {
+        } catch ( CatalogConnectionException | CatalogTransactionException | UnknownTableTypeException | UnknownTableException | UnknownKeyException | UnknownCollationException | UnknownTypeException | UnknownColumnException e ) {
             throw new GenericCatalogException( e );
         }
     }

--- a/catalog/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/CatalogImpl.java
+++ b/catalog/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/CatalogImpl.java
@@ -780,6 +780,8 @@ public class CatalogImpl extends Catalog {
                 if ( catalogKey.columnIds.contains( columnId ) ) {
                     throw new GenericCatalogException( "Unable to allow null values in a column that is part of the primary key." );
                 }
+            } else {
+                // TODO: Check that the column does not contain any null values
             }
 
             Statements.setNullable( transactionHandler, columnId, nullable );

--- a/catalog/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/Statements.java
+++ b/catalog/src/main/java/ch/unibas/dmi/dbis/polyphenydb/catalog/Statements.java
@@ -1401,7 +1401,7 @@ final class Statements {
 
 
     static CatalogForeignKey getForeignKey( XATransactionHandler transactionHandler, long foreignKeyId ) throws GenericCatalogException, UnknownForeignKeyException {
-        String keyFilter = " AND fk.\"id\" = " + foreignKeyId;
+        String keyFilter = " AND fk.\"key\" = " + foreignKeyId;
         List<CatalogForeignKey> foreignKeys = foreignKeyFilter( transactionHandler, keyFilter );
         if ( foreignKeys.size() > 1 ) {
             throw new GenericCatalogException( "More than one result. This combination of parameters should be unique. But it seams, it is not..." );

--- a/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/sql/SqlInsert.java
+++ b/core/src/main/java/ch/unibas/dmi/dbis/polyphenydb/sql/SqlInsert.java
@@ -50,6 +50,7 @@ import ch.unibas.dmi.dbis.polyphenydb.sql.validate.SqlValidator;
 import ch.unibas.dmi.dbis.polyphenydb.sql.validate.SqlValidatorScope;
 import ch.unibas.dmi.dbis.polyphenydb.util.ImmutableNullableList;
 import java.util.List;
+import lombok.Setter;
 
 
 /**
@@ -62,6 +63,7 @@ public class SqlInsert extends SqlCall {
     SqlNodeList keywords;
     SqlNode targetTable;
     SqlNode source;
+    @Setter
     SqlNodeList columnList;
 
 

--- a/dbms/src/main/java/ch/unibas/dmi/dbis/polyphenydb/processing/QueryProcessorImpl.java
+++ b/dbms/src/main/java/ch/unibas/dmi/dbis/polyphenydb/processing/QueryProcessorImpl.java
@@ -198,52 +198,62 @@ public class QueryProcessorImpl implements QueryProcessor, ViewExpander {
         // Add default values for unset fields
         if ( parsed.getKind() == SqlKind.INSERT ) {
             SqlInsert insert = (SqlInsert) parsed;
-            SqlNodeList columnList = insert.getTargetColumnList();
+            SqlNodeList oldColumnList = insert.getTargetColumnList();
             CatalogCombinedTable combinedTable = getCatalogCombinedTable( prepareContext, transaction, (SqlIdentifier) insert.getTargetTable() );
+            SqlNodeList newColumnList = new SqlNodeList( SqlParserPos.ZERO );
+            SqlNode[][] newValues = new SqlNode[((SqlBasicCall) insert.getSource()).getOperands().length][combinedTable.getColumns().size()];
+            int pos = 0;
             for ( CatalogColumn column : combinedTable.getColumns() ) {
-                if ( !checkIfSqlNodeListContains( columnList, column.name ) ) {
-                    // Add column
-                    columnList.add( new SqlIdentifier( column.name, SqlParserPos.ZERO ) );
-                    // Add value (loop because it can be a multi insert (insert into test(id) values (1),(2),(3))
-                    int i = 0;
-                    for ( SqlNode sqlNode : ((SqlBasicCall) insert.getSource()).getOperands() ) {
-                        SqlBasicCall call = (SqlBasicCall) sqlNode;
-                        // Create new values array and copy content of the old one
-                        SqlNode[] oldValues = call.getOperands();
-                        SqlNode[] newValues = new SqlNode[oldValues.length + 1];
-                        System.arraycopy( oldValues, 0, newValues, 0, oldValues.length );
+                // Add column
+                newColumnList.add( new SqlIdentifier( column.name, SqlParserPos.ZERO ) );
+
+                // Add value (loop because it can be a multi insert (insert into test(id) values (1),(2),(3))
+                int i = 0;
+                for ( SqlNode sqlNode : ((SqlBasicCall) insert.getSource()).getOperands() ) {
+                    SqlBasicCall call = (SqlBasicCall) sqlNode;
+                    int position = getPositionInSqlNodeList( oldColumnList, column.name );
+                    if ( position >= 0 ) {
+                        newValues[i][pos] = call.getOperands()[position];
+                    } else {
                         // Add value
                         if ( column.defaultValue != null ) {
                             CatalogDefaultValue defaultValue = column.defaultValue;
                             switch ( column.type ) {
                                 case BOOLEAN:
-                                    newValues[newValues.length - 1] = SqlLiteral.createBoolean( Boolean.parseBoolean( column.defaultValue.value ), SqlParserPos.ZERO );
+                                    newValues[i][pos] = SqlLiteral.createBoolean( Boolean.parseBoolean( column.defaultValue.value ), SqlParserPos.ZERO );
                                     break;
                                 case INTEGER:
                                 case DECIMAL:
                                 case BIGINT:
-                                    newValues[newValues.length - 1] = SqlLiteral.createExactNumeric( column.defaultValue.value, SqlParserPos.ZERO );
+                                    newValues[i][pos] = SqlLiteral.createExactNumeric( column.defaultValue.value, SqlParserPos.ZERO );
                                     break;
                                 case REAL:
                                 case DOUBLE:
-                                    newValues[newValues.length - 1] = SqlLiteral.createApproxNumeric( column.defaultValue.value, SqlParserPos.ZERO );
+                                    newValues[i][pos] = SqlLiteral.createApproxNumeric( column.defaultValue.value, SqlParserPos.ZERO );
                                     break;
                                 case VARCHAR:
                                 case TEXT:
-                                    newValues[newValues.length - 1] = SqlLiteral.createCharString( column.defaultValue.value, SqlParserPos.ZERO );
+                                    newValues[i][pos] = SqlLiteral.createCharString( column.defaultValue.value, SqlParserPos.ZERO );
                                     break;
                                 default:
                                     throw new PolyphenyDbException( "Not yet supported default value type: " + defaultValue.type );
                             }
                         } else if ( column.nullable ) {
-                            newValues[newValues.length - 1] = SqlLiteral.createNull( SqlParserPos.ZERO );
+                            newValues[i][pos] = SqlLiteral.createNull( SqlParserPos.ZERO );
                         } else {
-                            throw new PolyphenyDbException( "The not nullable field '" + column.name + " is missing in the insert statement and has no default value defined." );
+                            throw new PolyphenyDbException( "The not nullable field '" + column.name + "' is missing in the insert statement and has no default value defined." );
                         }
-                        // Replace value in parser tree
-                        ((SqlBasicCall) insert.getSource()).getOperands()[i++] = call.getOperator().createCall( call.getFunctionQuantifier(), call.getParserPosition(), newValues );
+                        i++;
                     }
+                    pos++;
                 }
+            }
+            // Add new column list
+            insert.setColumnList( newColumnList );
+            // Replace value in parser tree
+            for ( int i = 0; i < newValues.length; i++ ) {
+                SqlBasicCall call = ((SqlBasicCall) ((SqlBasicCall) insert.getSource()).getOperands()[i]);
+                ((SqlBasicCall) insert.getSource()).getOperands()[i] = call.getOperator().createCall( call.getFunctionQuantifier(), call.getParserPosition(), newValues[i] );
             }
         }
 
@@ -736,15 +746,21 @@ public class QueryProcessorImpl implements QueryProcessor, ViewExpander {
     }
 
 
-    private boolean checkIfSqlNodeListContains( SqlNodeList columnList, String name ) {
+    private int getPositionInSqlNodeList( SqlNodeList columnList, String name ) {
+        int i = 0;
         for ( SqlNode node : columnList.getList() ) {
             SqlIdentifier identifier = (SqlIdentifier) node;
             if ( RuntimeConfig.CASE_SENSITIVE.getBoolean() ) {
-                return identifier.getSimple().equals( name );
+                if ( identifier.getSimple().equals( name ) ) {
+                    return i;
+                }
             } else {
-                return identifier.getSimple().equalsIgnoreCase( name );
+                if ( identifier.getSimple().equalsIgnoreCase( name ) ) {
+                    return i;
+                }
             }
+            i++;
         }
-        return false;
+        return -1;
     }
 }

--- a/dbms/src/main/java/ch/unibas/dmi/dbis/polyphenydb/processing/TransactionImpl.java
+++ b/dbms/src/main/java/ch/unibas/dmi/dbis/polyphenydb/processing/TransactionImpl.java
@@ -67,7 +67,6 @@ public class TransactionImpl implements Transaction {
 
     private QueryProcessor queryProcessor;
     private Catalog catalog;
-    private PolyphenyDbSchema schema;
 
     @Getter
     private CatalogUser user;

--- a/dbms/src/main/java/ch/unibas/dmi/dbis/polyphenydb/schema/PolySchemaBuilder.java
+++ b/dbms/src/main/java/ch/unibas/dmi/dbis/polyphenydb/schema/PolySchemaBuilder.java
@@ -88,10 +88,13 @@ public class PolySchemaBuilder {
         for ( CatalogCombinedSchema combinedSchema : combinedDatabase.getSchemas() ) {
             Map<String, Table> tableMap = new HashMap<>();
             SchemaPlus s = new SimplePolyphenyDbSchema( polyphenyDbSchema, new AbstractSchema(), combinedSchema.getSchema().name ).plus();
+            // Create schema on stores
+            for ( Store store : StoreManager.getInstance().getStores().values() ) {
+                store.createNewSchema( rootSchema, combinedSchema.getSchema().name );
+            }
             for ( CatalogCombinedTable combinedTable : combinedSchema.getTables() ) {
                 int storeId = combinedTable.getPlacements().get( 0 ).storeId;
                 Store store = StoreManager.getInstance().getStore( storeId );
-                store.createNewSchema( rootSchema, combinedSchema.getSchema().name );
                 Table table = store.createTableSchema( combinedTable );
                 s.add( combinedTable.getTable().name, table );
                 tableMap.put( combinedTable.getTable().name, table );

--- a/dbms/src/test/java/ch/unibas/dmi/dbis/polyphenydb/jdbc/JdbcMetaTest.java
+++ b/dbms/src/test/java/ch/unibas/dmi/dbis/polyphenydb/jdbc/JdbcMetaTest.java
@@ -86,8 +86,8 @@ public class JdbcMetaTest {
             Connection connection = polyphenyDbConnection.getConnection();
             try ( Statement statement = connection.createStatement() ) {
                 statement.executeUpdate( "CREATE SCHEMA test" );
-                statement.executeUpdate( "CREATE TABLE foo( id INTEGER, name VARCHAR(20) NULL, bar VARCHAR(33) NOT NULL COLLATE CASE SENSITIVE, PRIMARY KEY (id) )" );
-                statement.executeUpdate( "CREATE TABLE test.foo2( id INTEGER, name VARCHAR(20) NULL, foobar VARCHAR(33) NOT NULL, PRIMARY KEY (id, name) )" );
+                statement.executeUpdate( "CREATE TABLE foo( id INTEGER NOT NULL, name VARCHAR(20) NULL, bar VARCHAR(33) COLLATE CASE SENSITIVE, PRIMARY KEY (id) )" );
+                statement.executeUpdate( "CREATE TABLE test.foo2( id INTEGER NOT NULL, name VARCHAR(20) NOT NULL, foobar VARCHAR(33) NULL, PRIMARY KEY (id, name) )" );
                 statement.executeUpdate( "ALTER TABLE test.foo2 ADD CONSTRAINT u_foo1 UNIQUE (name, foobar)" );
                 statement.executeUpdate( "ALTER TABLE foo ADD CONSTRAINT fk_foo_1 FOREIGN KEY (name, bar) REFERENCES test.foo2(name, foobar) ON UPDATE CASCADE ON DELETE SET NULL" );
                 statement.executeUpdate( "ALTER TABLE test.foo2 ADD CONSTRAINT fk_foo_2 FOREIGN KEY (id) REFERENCES public.foo(id)" );
@@ -190,9 +190,9 @@ public class JdbcMetaTest {
             Assert.assertEquals( "Wrong column name", "COLLATION", rsmd.getColumnName( 19 ) );
 
             // Check data
-            final Object[] columnId = new Object[]{ "APP", "public", "foo", "id", 4, "INTEGER", null, null, null, null, 1, "", null, null, null, null, 1, "YES", null };
+            final Object[] columnId = new Object[]{ "APP", "public", "foo", "id", 4, "INTEGER", null, null, null, null, 0, "", null, null, null, null, 1, "NO", null };
             final Object[] columnName = new Object[]{ "APP", "public", "foo", "name", 12, "VARCHAR", 20, null, null, null, 1, "", null, null, null, null, 2, "YES", "CASE_INSENSITIVE" };
-            final Object[] columnBar = new Object[]{ "APP", "public", "foo", "bar", 12, "VARCHAR", 33, null, null, null, 0, "", null, null, null, null, 3, "NO", "CASE_SENSITIVE" };
+            final Object[] columnBar = new Object[]{ "APP", "public", "foo", "bar", 12, "VARCHAR", 33, null, null, null, 1, "", null, null, null, null, 3, "YES", "CASE_SENSITIVE" };
             checkResultSet(
                     connection.getMetaData().getColumns( "APP", null, "foo", null ),
                     ImmutableList.of( columnId, columnName, columnBar ) );


### PR DESCRIPTION
- Allow the columns in a SQL insert statement to have an arbitrary order 
- Ensure that columns which are part of the primary key are not nullable 
- Simplify dropping of tables with self-referencing foreign keys
- Check if the data type of the referenced column of a foreign key constraint matches the data type of the referencing column